### PR TITLE
Clean up and fix up buildscript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ task sortArtifacts(type: Copy) {
     //Put each jar with a classifier in a subfolder with the classifier as its name
     eachFile {
         //This matcher is used to get the classifier of the jar
-        def matcher = Pattern.compile("$config.mod_name-$version-(?<classifier>\w+).jar").matcher(it.name)
+        def matcher = Pattern.compile("$config.mod_name-$version-(?<classifier>\\w+).jar").matcher(it.name)
         //Only change the destination for full matches, i.e jars with classifiers
         if (matcher.matches())
         {


### PR DESCRIPTION
I noticed the buildscript was a bit messy and had an issue, so I cleaned it up and fixed the issue.
**Changes**:
* wtfGradle1, wtfGradle2, output, outputDeobf, & sort are now one task, sortArtifacts. It copies the unclassified .jar into `config.dir_output` & the classified .jars into subfolders of `config.dir_output` named after their classifiers.
* Moved content of incrementBuildNumber into a `doFirst` closure, so it's only run when incrementBuildNumber is actually run. Anything in a task that's not in a `doFirst` or `doLast` closure is run when tasks are configured. This was causing the build number to be incremented every time any gradle task(s) were run.

All the changes are commented for the benefit of other people who are tinkering with the build.gradle. I wasn't sure how much to comment, so I commented all but the very obvious.