### PR TITLE
De-Hardcode PageQuest completion checking

### DIFF
--- a/Common/src/main/java/vazkii/patchouli/client/book/BookEntry.java
+++ b/Common/src/main/java/vazkii/patchouli/client/book/BookEntry.java
@@ -15,6 +15,7 @@ import vazkii.patchouli.client.base.PersistentData;
 import vazkii.patchouli.client.base.PersistentData.DataHolder.BookData;
 import vazkii.patchouli.client.book.page.PageEmpty;
 import vazkii.patchouli.client.book.page.PageQuest;
+import vazkii.patchouli.client.book.page.abstr.CompletablePage;
 import vazkii.patchouli.common.base.PatchouliConfig;
 import vazkii.patchouli.common.book.Book;
 import vazkii.patchouli.common.util.ItemStackUtil;
@@ -288,7 +289,7 @@ public class BookEntry extends AbstractReadStateHolder implements Comparable<Boo
 		}
 
 		for (BookPage page : pages) {
-			if (page instanceof PageQuest && ((PageQuest) page).isCompleted(book)) {
+			if (page instanceof CompletablePage && ((CompletablePage) page).isCompleted(book)) {
 				return EntryDisplayState.COMPLETED;
 			}
 		}

--- a/Common/src/main/java/vazkii/patchouli/client/book/page/PageQuest.java
+++ b/Common/src/main/java/vazkii/patchouli/client/book/page/PageQuest.java
@@ -16,10 +16,11 @@ import vazkii.patchouli.client.book.BookContentsBuilder;
 import vazkii.patchouli.client.book.BookEntry;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.gui.GuiBookEntry;
+import vazkii.patchouli.client.book.page.abstr.CompletablePage;
 import vazkii.patchouli.client.book.page.abstr.PageWithText;
 import vazkii.patchouli.common.book.Book;
 
-public class PageQuest extends PageWithText {
+public class PageQuest extends PageWithText implements CompletablePage {
 
 	ResourceLocation trigger;
 	String title;

--- a/Common/src/main/java/vazkii/patchouli/client/book/page/abstr/CompletablePage.java
+++ b/Common/src/main/java/vazkii/patchouli/client/book/page/abstr/CompletablePage.java
@@ -1,0 +1,9 @@
+package vazkii.patchouli.client.book.page.abstr;
+
+import vazkii.patchouli.common.book.Book;
+
+public interface CompletablePage {
+	
+	boolean isCompleted(Book book);
+	
+}


### PR DESCRIPTION
Currently, BookEntry explicitly searches for QuestPages for determining if the entry should be marked as complete.
That means that all custom pages, that want to use that functionality have to be extended from QuestPage.

Since a lot of QuestPages' properties are package private that makes it really hard to create pages with a layout that differ from PageQuest (like not having the button, or an entirely different layout).

Moving the check for completion to an Interface makes custom pages that utilize isCompleted() much more easy to handle.