### PR TITLE
Fix liquid block rendering in multiblock in-page rendering

### DIFF
--- a/Common/src/main/java/vazkii/patchouli/client/book/LiquidBlockVertexConsumer.java
+++ b/Common/src/main/java/vazkii/patchouli/client/book/LiquidBlockVertexConsumer.java
@@ -1,0 +1,59 @@
+package vazkii.patchouli.client.book;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.core.BlockPos;
+
+/**
+ * Since {@link net.minecraft.client.renderer.block.LiquidBlockRenderer} doesn't use the pose stack at all, we need to both (1) un-transform the positions by {@code pos}, and also re-transform them using the {@link PoseStack}.
+ */
+public record LiquidBlockVertexConsumer(VertexConsumer prior, PoseStack pose, BlockPos pos) implements VertexConsumer {
+
+    @Override
+    public VertexConsumer vertex(double x, double y, double z) {
+        final float dx = pos.getX() & 15;
+        final float dy = pos.getY() & 15;
+        final float dz = pos.getZ() & 15;
+        return prior.vertex(pose.last().pose(), (float)x - dx, (float)y - dy, (float)z - dz);
+    }
+
+    @Override
+    public VertexConsumer color(int r, int g, int b, int a) {
+        return prior.color(r, g, b, a);
+    }
+
+    @Override
+    public VertexConsumer uv(float u, float v) {
+        return prior.uv(u, v);
+    }
+
+    @Override
+    public VertexConsumer overlayCoords(int u, int v) {
+        return prior.overlayCoords(u, v);
+    }
+
+    @Override
+    public VertexConsumer uv2(int u, int v) {
+        return prior.uv2(u, v);
+    }
+
+    @Override
+    public VertexConsumer normal(float x, float y, float z) {
+        return prior.normal(pose.last().normal(), x, y, z);
+    }
+
+    @Override
+    public void endVertex() {
+        prior.endVertex();
+    }
+
+    @Override
+    public void defaultColor(int r, int g, int b, int a) {
+        prior.defaultColor(r, g, b, a);
+    }
+
+    @Override
+    public void unsetDefaultColor() {
+        prior.unsetDefaultColor();
+    }
+}

--- a/Common/src/main/java/vazkii/patchouli/client/book/LiquidBlockVertexConsumer.java
+++ b/Common/src/main/java/vazkii/patchouli/client/book/LiquidBlockVertexConsumer.java
@@ -2,58 +2,60 @@ package vazkii.patchouli.client.book;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+
 import net.minecraft.core.BlockPos;
 
 /**
- * Since {@link net.minecraft.client.renderer.block.LiquidBlockRenderer} doesn't use the pose stack at all, we need to both (1) un-transform the positions by {@code pos}, and also re-transform them using the {@link PoseStack}.
+ * Since {@link net.minecraft.client.renderer.block.LiquidBlockRenderer} doesn't use the pose stack at all, we need to
+ * both (1) un-transform the positions by {@code pos}, and also re-transform them using the {@link PoseStack}.
  */
 public record LiquidBlockVertexConsumer(VertexConsumer prior, PoseStack pose, BlockPos pos) implements VertexConsumer {
 
-    @Override
-    public VertexConsumer vertex(double x, double y, double z) {
-        final float dx = pos.getX() & 15;
-        final float dy = pos.getY() & 15;
-        final float dz = pos.getZ() & 15;
-        return prior.vertex(pose.last().pose(), (float)x - dx, (float)y - dy, (float)z - dz);
-    }
+	@Override
+	public VertexConsumer vertex(double x, double y, double z) {
+		final float dx = pos.getX() & 15;
+		final float dy = pos.getY() & 15;
+		final float dz = pos.getZ() & 15;
+		return prior.vertex(pose.last().pose(), (float) x - dx, (float) y - dy, (float) z - dz);
+	}
 
-    @Override
-    public VertexConsumer color(int r, int g, int b, int a) {
-        return prior.color(r, g, b, a);
-    }
+	@Override
+	public VertexConsumer color(int r, int g, int b, int a) {
+		return prior.color(r, g, b, a);
+	}
 
-    @Override
-    public VertexConsumer uv(float u, float v) {
-        return prior.uv(u, v);
-    }
+	@Override
+	public VertexConsumer uv(float u, float v) {
+		return prior.uv(u, v);
+	}
 
-    @Override
-    public VertexConsumer overlayCoords(int u, int v) {
-        return prior.overlayCoords(u, v);
-    }
+	@Override
+	public VertexConsumer overlayCoords(int u, int v) {
+		return prior.overlayCoords(u, v);
+	}
 
-    @Override
-    public VertexConsumer uv2(int u, int v) {
-        return prior.uv2(u, v);
-    }
+	@Override
+	public VertexConsumer uv2(int u, int v) {
+		return prior.uv2(u, v);
+	}
 
-    @Override
-    public VertexConsumer normal(float x, float y, float z) {
-        return prior.normal(pose.last().normal(), x, y, z);
-    }
+	@Override
+	public VertexConsumer normal(float x, float y, float z) {
+		return prior.normal(pose.last().normal(), x, y, z);
+	}
 
-    @Override
-    public void endVertex() {
-        prior.endVertex();
-    }
+	@Override
+	public void endVertex() {
+		prior.endVertex();
+	}
 
-    @Override
-    public void defaultColor(int r, int g, int b, int a) {
-        prior.defaultColor(r, g, b, a);
-    }
+	@Override
+	public void defaultColor(int r, int g, int b, int a) {
+		prior.defaultColor(r, g, b, a);
+	}
 
-    @Override
-    public void unsetDefaultColor() {
-        prior.unsetDefaultColor();
-    }
+	@Override
+	public void unsetDefaultColor() {
+		prior.unsetDefaultColor();
+	}
 }

--- a/Common/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/test/multiblock_with_liquids.json
+++ b/Common/src/main/resources/data/patchouli/patchouli_books/testbook1/en_us/entries/test/multiblock_with_liquids.json
@@ -1,0 +1,38 @@
+{
+	"name": "Multiblock with Liquids",
+	"icon": "minecraft:textures/item/emerald.png",
+	"category": "patchouli:intro/butts",
+	"read_by_default": false,
+	"pages": [
+		{
+			"type": "patchouli:multiblock",
+			"multiblock_id": "",
+			"name": "Team Steve",
+			"text": "Testing a multiblock with liquids and also waterlogged blocks.",
+			"multiblock": {
+				"pattern": [
+					[
+						"GG   GG",
+						" LLLLLG",
+						"GGGGGGG",
+						" WW0WWG",
+						"GGGGGGG",
+						" SSSSSG",
+						"GG   GG"
+					]
+				],
+				"mapping": {
+					" ": "ANY",
+					"0": "minecraft:lapis_block",
+					"G": "minecraft:bricks",
+					"W": "minecraft:water",
+					"L": "minecraft:lava",
+					"S": "minecraft:brick_slab[type=bottom,waterlogged=true]"
+				},
+				"symmetrical": false,
+				"offset": [0, 0, 0],
+				"view_offset": [0, 0, 0]
+			}
+		}
+	]
+}

--- a/Fabric/src/main/java/vazkii/patchouli/fabric/client/FabricClientXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/patchouli/fabric/client/FabricClientXplatImpl.java
@@ -2,13 +2,19 @@ package vazkii.patchouli.fabric.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 
+import net.minecraft.world.level.material.FluidState;
+import vazkii.patchouli.client.book.LiquidBlockVertexConsumer;
 import vazkii.patchouli.xplat.IClientXplatAbstractions;
 
 import java.util.Random;
@@ -16,9 +22,17 @@ import java.util.Random;
 public class FabricClientXplatImpl implements IClientXplatAbstractions {
 	@Override
 	public void renderForMultiblock(BlockState state, BlockPos pos, BlockAndTintGetter multiblock, PoseStack ps, MultiBufferSource buffers, Random rand) {
-		var layer = ItemBlockRenderTypes.getChunkRenderType(state);
-		var buffer = buffers.getBuffer(layer);
-		Minecraft.getInstance().getBlockRenderer()
-				.renderBatched(state, pos, multiblock, ps, buffer, false, rand);
+		final BlockRenderDispatcher blockRenderer = Minecraft.getInstance().getBlockRenderer();
+		final FluidState fluidState = state.getFluidState();
+		if (!fluidState.isEmpty()) {
+			final RenderType layer = ItemBlockRenderTypes.getRenderLayer(fluidState);
+			final VertexConsumer buffer = buffers.getBuffer(layer);
+			blockRenderer.renderLiquid(pos, multiblock, new LiquidBlockVertexConsumer(buffer, ps, pos), state, fluidState);
+		}
+		if (state.getRenderShape() != RenderShape.INVISIBLE) {
+			final RenderType layer = ItemBlockRenderTypes.getChunkRenderType(state);
+			final VertexConsumer buffer = buffers.getBuffer(layer);
+			blockRenderer.renderBatched(state, pos, multiblock, ps, buffer, false, rand);
+		}
 	}
 }

--- a/Fabric/src/main/java/vazkii/patchouli/fabric/client/FabricClientXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/patchouli/fabric/client/FabricClientXplatImpl.java
@@ -1,8 +1,8 @@
 package vazkii.patchouli.fabric.client;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-
 import com.mojang.blaze3d.vertex.VertexConsumer;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -12,8 +12,8 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
-
 import net.minecraft.world.level.material.FluidState;
+
 import vazkii.patchouli.client.book.LiquidBlockVertexConsumer;
 import vazkii.patchouli.xplat.IClientXplatAbstractions;
 

--- a/Forge/src/main/java/vazkii/patchouli/forge/client/ForgeClientXplatImpl.java
+++ b/Forge/src/main/java/vazkii/patchouli/forge/client/ForgeClientXplatImpl.java
@@ -13,8 +13,8 @@ import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.FluidState;
 import net.minecraftforge.client.ForgeHooksClient;
-
 import net.minecraftforge.client.model.data.EmptyModelData;
+
 import vazkii.patchouli.client.book.LiquidBlockVertexConsumer;
 import vazkii.patchouli.xplat.IClientXplatAbstractions;
 


### PR DESCRIPTION
- Fixes #534.
- Notably does not render anything in the visualization, but works in the page for both fluids and waterlogged blocks.
- Added a test page with some water, lava, and waterlogged slabs as an example.

Example:

![2022-06-05_13 11 28](https://user-images.githubusercontent.com/35673674/172062373-d1689daf-6d93-4078-9c2a-cbd0cc23e0c7.png)

