### PR TITLE
Update default creative tab

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -144,7 +144,7 @@ public class Book {
 		this.indexIconRaw = GsonHelper.getAsString(root, "index_icon", "");
 		this.version = GsonHelper.getAsString(root, "version", "0");
 		this.subtitle = GsonHelper.getAsString(root, "subtitle", "");
-		this.creativeTab = GsonHelper.getAsString(root, "creative_tab", "misc");
+		this.creativeTab = GsonHelper.getAsString(root, "creative_tab", "tools");
 		this.advancementsTab = SerializationUtil.getAsResourceLocation(root, "advancements_tab", null);
 		this.noBook = GsonHelper.getAsBoolean(root, "dont_generate_book", false);
 		this.showToasts = GsonHelper.getAsBoolean(root, "show_toasts", true);

--- a/web/docs/patchouli-basics/getting-started.md
+++ b/web/docs/patchouli-basics/getting-started.md
@@ -78,7 +78,7 @@ Format](/docs/reference/book-json). (highly recommended!)
 
 ### 4. Check ingame
 Load your game and check if your book is there. Unless you specified otherwise, it should
-be in the Miscellaneous creative tab, but you can also search for it.
+be in the Tools & Utilities creative tab, but you can also search for it.
 
 If you don't see it, check if Patchouli is properly loaded and if there's any errors in
 your log.

--- a/web/docs/reference/book-json.md
+++ b/web/docs/reference/book-json.md
@@ -146,7 +146,7 @@ landing page if "version" is set to "0" or not set.
 
 * **creative_tab** (String)
 
-The creative tab to display your book in. This defaults to Miscellaneous, but you can move
+The creative tab to display your book in. This defaults to Tools & Utilities, but you can move
 it to any tab you wish. Here are the names for the vanilla tabs:
 
 1. buildingBlocks


### PR DESCRIPTION
Changed from Miscellaneous to Tools & Utilities - as of 1.19.3, the Miscellaneous tab no longer exists.

Items not in a creative tab furthermore cannot be searched for in the creative inventory. This may lead to confusion ([see my question in the Discord](https://discord.com/channels/154261184701267969/507986764237897728/1094622153846030427))