### PR TITLE
Fixed Forge Dependency (Shouldn't be above recommended)

### DIFF
--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -61,7 +61,7 @@ minecraft {
 }
 
 dependencies {
-    minecraft "net.minecraftforge:forge:${mc_version}-47.1.1"
+    minecraft "net.minecraftforge:forge:${mc_version}-47.1.0"
     implementation project(":Xplat")
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -16,7 +16,7 @@ Accessible, Data-Driven, Dependency-Free Documentation for Minecraft Modders and
 [[dependencies.patchouli]]
 modId="forge"
 mandatory=true
-versionRange="[47.1.1,)"
+versionRange="[47.1.0,)"
 
 [[dependencies.patchouli]]
 modId="minecraft"


### PR DESCRIPTION
Many servers shouldnt be forced to update above the recommended Forge Version just for in-game documentation...
47.1.0 is the recommended version, not 47.1.1