### PR TITLE
Fix #696

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
@@ -312,7 +312,7 @@ public abstract class GuiBook extends Screen {
 		}
 		}
 
-		for(GuiEventListener listener : children()) {
+		for (GuiEventListener listener : children()) {
 			if (listener.mouseClicked(mouseX, mouseY, mouseButton)) {
 				if (mouseButton == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
 					setDragging(true);

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
@@ -312,7 +312,15 @@ public abstract class GuiBook extends Screen {
 		}
 		}
 
-		return super.mouseClicked(mouseX, mouseY, mouseButton);
+		for(GuiEventListener listener : children()) {
+			if (listener.mouseClicked(mouseX, mouseY, mouseButton)) {
+				if (mouseButton == GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+					setDragging(true);
+				}
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Details and reproduction steps are in the linked issue.

### Description

In `mouseClicked`, the boolean return is if the button should set (and clear) `isFocused()`. For some buttons, it makes sense that clicking them should start and keep focus but this creates undesirable situations for Patchouli's buttons, i.e. the page turn buttons. By always returning `false`, and only for `mouseClicked()`, this prevents the button from becoming persistently focused when clicking or scrolling.

Note that this still preserves tab-style operation of the gui - the focus will still be set, and be persistent while tab/enter/arrow keys are being used. It can still create "sticky-tooltip" type situations if both mouse-based and tab-based interaction are mixed.

Video of the fixed behavior (demonstrating both mouse-based interaction, and then tab-based interaction working as intended):

https://github.com/VazkiiMods/Patchouli/assets/35673674/aa19c854-03e8-46f8-add6-508c7d7a459b

