### PR TITLE
Fire an advancement trigger when reading a book

### DIFF
--- a/Fabric/src/main/java/vazkii/patchouli/fabric/common/FabricModInitializer.java
+++ b/Fabric/src/main/java/vazkii/patchouli/fabric/common/FabricModInitializer.java
@@ -12,6 +12,7 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 
+import vazkii.patchouli.common.advancement.PatchouliCriteriaTriggers;
 import vazkii.patchouli.common.base.PatchouliSounds;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.command.OpenBookCommand;
@@ -26,6 +27,7 @@ public class FabricModInitializer implements ModInitializer {
 		PatchouliSounds.submitRegistrations((id, e) -> Registry.register(BuiltInRegistries.SOUND_EVENT, id, e));
 		PatchouliItems.submitItemRegistrations((id, e) -> Registry.register(BuiltInRegistries.ITEM, id, e));
 		PatchouliItems.submitRecipeSerializerRegistrations((id, e) -> Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, id, e));
+		PatchouliCriteriaTriggers.submitTriggerRegistrations((id, e) -> Registry.register(BuiltInRegistries.TRIGGER_TYPES, id, e));
 		FiberPatchouliConfig.setup();
 		CommandRegistrationCallback.EVENT.register((disp, buildCtx, selection) -> OpenBookCommand.register(disp));
 		UseBlockCallback.EVENT.register(LecternEventHandler::rightClick);

--- a/NeoForge/src/main/java/vazkii/patchouli/neoforge/common/NeoForgeModInitializer.java
+++ b/NeoForge/src/main/java/vazkii/patchouli/neoforge/common/NeoForgeModInitializer.java
@@ -16,6 +16,7 @@ import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.registries.RegisterEvent;
 
 import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.common.advancement.PatchouliCriteriaTriggers;
 import vazkii.patchouli.common.base.PatchouliSounds;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.command.OpenBookCommand;
@@ -45,6 +46,7 @@ public class NeoForgeModInitializer {
 		evt.register(Registries.RECIPE_SERIALIZER, rh -> {
 			PatchouliItems.submitRecipeSerializerRegistrations(rh::register);
 		});
+		evt.register(Registries.TRIGGER_TYPE, rh -> PatchouliCriteriaTriggers.submitTriggerRegistrations(rh::register));
 	}
 
 	@SubscribeEvent

--- a/Xplat/src/main/java/vazkii/patchouli/common/advancement/BookOpenTrigger.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/advancement/BookOpenTrigger.java
@@ -1,0 +1,52 @@
+package vazkii.patchouli.common.advancement;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.advancements.critereon.*;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.ExtraCodecs;
+
+import vazkii.patchouli.api.PatchouliAPI;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * An advancement trigger for opening Patchouli books.
+ */
+public class BookOpenTrigger extends SimpleCriterionTrigger<BookOpenTrigger.TriggerInstance> {
+	public static final ResourceLocation ID = new ResourceLocation(PatchouliAPI.MOD_ID, "open_book");
+	public static final BookOpenTrigger INSTANCE = new BookOpenTrigger();
+
+	@NotNull
+	@Override
+	public Codec<TriggerInstance> codec() {
+		return BookOpenTrigger.TriggerInstance.CODEC;
+	}
+
+	public void trigger(@NotNull ServerPlayer player, @NotNull ResourceLocation book) {
+		trigger(player, instance -> instance.matches(book, null, 0));
+	}
+
+	public void trigger(@NotNull ServerPlayer player, @NotNull ResourceLocation book, @Nullable ResourceLocation entry, int page) {
+		trigger(player, instance -> instance.matches(book, entry, page));
+	}
+
+	public record TriggerInstance(Optional<ContextAwarePredicate> player, ResourceLocation book, Optional<ResourceLocation> entry, MinMaxBounds.Ints page) implements SimpleInstance {
+
+		public static Codec<BookOpenTrigger.TriggerInstance> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+				ExtraCodecs.strictOptionalField(EntityPredicate.ADVANCEMENT_CODEC, "player").forGetter(TriggerInstance::player),
+				ResourceLocation.CODEC.fieldOf("book").forGetter(TriggerInstance::book),
+				ExtraCodecs.strictOptionalField(ResourceLocation.CODEC, "entry").forGetter(TriggerInstance::entry),
+				ExtraCodecs.strictOptionalField(MinMaxBounds.Ints.CODEC, "page", MinMaxBounds.Ints.ANY).forGetter(TriggerInstance::page)
+		).apply(instance, TriggerInstance::new));
+
+		public boolean matches(@NotNull ResourceLocation book, @Nullable ResourceLocation entry, int page) {
+			return this.book.equals(book) && (this.entry.isEmpty() || this.entry.get().equals(entry)) && this.page.matches(page);
+		}
+	}
+}

--- a/Xplat/src/main/java/vazkii/patchouli/common/advancement/PatchouliCriteriaTriggers.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/advancement/PatchouliCriteriaTriggers.java
@@ -1,0 +1,14 @@
+package vazkii.patchouli.common.advancement;
+
+import net.minecraft.advancements.CriterionTrigger;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.function.BiConsumer;
+
+public class PatchouliCriteriaTriggers {
+	public static final BookOpenTrigger BOOK_OPEN = new BookOpenTrigger();
+
+	public static void submitTriggerRegistrations(BiConsumer<ResourceLocation, CriterionTrigger<?>> consumer) {
+		consumer.accept(BookOpenTrigger.ID, BOOK_OPEN);
+	}
+}

--- a/Xplat/src/main/java/vazkii/patchouli/common/base/PatchouliAPIImpl.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/base/PatchouliAPIImpl.java
@@ -28,6 +28,7 @@ import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.template.BookTemplate;
 import vazkii.patchouli.client.book.text.BookTextParser;
 import vazkii.patchouli.client.handler.MultiblockVisualizationHandler;
+import vazkii.patchouli.common.advancement.BookOpenTrigger;
 import vazkii.patchouli.common.book.Book;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.item.ItemModBook;
@@ -80,11 +81,13 @@ public class PatchouliAPIImpl implements IPatchouliAPI {
 
 	@Override
 	public void openBookGUI(ServerPlayer player, ResourceLocation book) {
+		BookOpenTrigger.INSTANCE.trigger(player, book);
 		IXplatAbstractions.INSTANCE.sendOpenBookGui(player, book, null, 0);
 	}
 
 	@Override
 	public void openBookEntry(ServerPlayer player, ResourceLocation book, ResourceLocation entry, int page) {
+		BookOpenTrigger.INSTANCE.trigger(player, book, entry, page);
 		IXplatAbstractions.INSTANCE.sendOpenBookGui(player, book, entry, page);
 	}
 


### PR DESCRIPTION
Trigger condition uses the book's resource location, and optionally a specific entry resource location and page number. However, the latter are only triggered by server code opening the book at that entry and page, not by the player going there via interactions with the opened book.