### PR TITLE
Fix some bugs found on forgecraft

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/base/ClientAdvancements.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/base/ClientAdvancements.java
@@ -1,7 +1,5 @@
 package vazkii.patchouli.client.base;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementProgress;
 import net.minecraft.client.Minecraft;
@@ -83,14 +81,11 @@ public class ClientAdvancements {
 		@NotNull
 		@Override
 		public Visibility render(GuiGraphics graphics, ToastComponent toastGui, long delta) {
-			RenderSystem.setShaderTexture(0, BACKGROUND_SPRITE);
-
-			RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
-			graphics.blit(BACKGROUND_SPRITE, 0, 0, 0, 32, 160, 32);
+			graphics.blitSprite(BACKGROUND_SPRITE, 0, 0, width(), height());
 
 			Font font = toastGui.getMinecraft().font;
-			graphics.drawString(font, Component.translatable(book.name), 30, 7, -11534256, false);
-			graphics.drawString(font, Component.translatable("patchouli.gui.lexicon.toast.info"), 30, 17, -16777216, false);
+			graphics.drawString(font, Component.translatable(book.name), 30, 7, 0xfff000f0, false);
+			graphics.drawString(font, Component.translatable("patchouli.gui.lexicon.toast.info"), 30, 17, 0xffffffff, false);
 
 			graphics.renderItem(book.getBookItem(), 8, 8);
 			graphics.renderItemDecorations(font, book.getBookItem(), 8, 8);

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBookEntryList.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBookEntryList.java
@@ -92,7 +92,7 @@ public abstract class GuiBookEntryList extends GuiBook {
 			drawSeparator(graphics, book, LEFT_PAGE_X, TOP_PADDING + 12);
 			drawSeparator(graphics, book, RIGHT_PAGE_X, TOP_PADDING + 12);
 
-			text.render(graphics, mouseX, mouseY);
+			text.render(graphics, mouseX, mouseY, partialTicks);
 			if (shouldDrawProgressBar()) {
 				drawProgressBar(graphics, book, mouseX, mouseY, this::doesEntryCountForProgress);
 			}

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBookLanding.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBookLanding.java
@@ -115,7 +115,7 @@ public class GuiBookLanding extends GuiBook {
 	@Override
 	void drawForegroundElements(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		if (text != null) {
-			text.render(graphics, mouseX, mouseY);
+			text.render(graphics, mouseX, mouseY, partialTicks);
 		}
 
 		int topSeparator = TOP_PADDING + 12;

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBookWriter.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBookWriter.java
@@ -61,10 +61,12 @@ public class GuiBookWriter extends GuiBook {
 			textfield.setFocused(true);
 			return true;
 		}
-		if (text.click(mouseX, mouseY, mouseButton))
+		if (text.click(mouseX, mouseY, mouseButton)) {
 			return true;
-		if (editableText.click(mouseX, mouseY, mouseButton))
+		}
+		if (editableText.click(mouseX, mouseY, mouseButton)) {
 			return true;
+		}
 		return super.mouseClickedScaled(mouseX, mouseY, mouseButton);
 	}
 

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBook.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBook.java
@@ -36,8 +36,9 @@ public class GuiButtonBook extends Button {
 	@Override
 	public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
 		active = displayCondition.get();
-		if (!active)
+		if (!active) {
 			return;
+		}
 		RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
 		GuiBook.drawFromTexture(graphics, parent.book, getX(), getY(), u + (isHoveredOrFocused() ? width : 0), v, width, height);
 		if (isHoveredOrFocused()) {

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBook.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/button/GuiButtonBook.java
@@ -35,7 +35,9 @@ public class GuiButtonBook extends Button {
 
 	@Override
 	public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
-		active = visible = displayCondition.get();
+		active = displayCondition.get();
+		if (!active)
+			return;
 		RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
 		GuiBook.drawFromTexture(graphics, parent.book, getX(), getY(), u + (isHoveredOrFocused() ? width : 0), v, width, height);
 		if (isHoveredOrFocused()) {

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/page/abstr/PageWithText.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/page/abstr/PageWithText.java
@@ -30,7 +30,7 @@ public abstract class PageWithText extends BookPage {
 	@Override
 	public void render(GuiGraphics graphics, int mouseX, int mouseY, float pticks) {
 		if (shouldRenderText()) {
-			textRender.render(graphics, mouseX, mouseY);
+			textRender.render(graphics, mouseX, mouseY, pticks);
 		}
 	}
 

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/template/component/ComponentText.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/template/component/ComponentText.java
@@ -52,7 +52,7 @@ public class ComponentText extends TemplateComponent {
 
 	@Override
 	public void render(GuiGraphics graphics, BookPage page, int mouseX, int mouseY, float pticks) {
-		textRenderer.render(graphics, mouseX, mouseY);
+		textRenderer.render(graphics, mouseX, mouseY, pticks);
 	}
 
 	@Override


### PR DESCRIPTION
- Fixes previous page button missing
- Fixes previous and next page buttons being rendered for 1 tick when navigating
- Fixes entry unlock toast having the wrong colors and using the missing texture
- Fixes text input not being selectable in book editor