### PR TITLE
Update discord invite link in the patchi wiki

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -55,7 +55,7 @@ module.exports = {
             },
             {
               label: 'Discord',
-              href: 'https://discord.com/invite/vazkii',
+              href: 'https://discord.com/invite/vm',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
fixes the link for the discord invite on [the patchi docs](https://vazkiimods.github.io/Patchouli/docs/intro)