### PR TITLE
Add fields to the recipe pages for disabling the linking of the recipe

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipe.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipe.java
@@ -16,6 +16,8 @@ public abstract class PageDoubleRecipe<T> extends PageWithText {
 
 	@SerializedName("recipe") ResourceLocation recipeId;
 	@SerializedName("recipe2") ResourceLocation recipe2Id;
+	@SerializedName("link_recipe") boolean linkRecipe = true;
+	@SerializedName("link_recipe2") boolean linkRecipe2 = true;
 	String title;
 
 	protected transient T recipe1, recipe2;
@@ -25,8 +27,8 @@ public abstract class PageDoubleRecipe<T> extends PageWithText {
 	public void build(Level level, BookEntry entry, BookContentsBuilder builder, int pageNum) {
 		super.build(level, entry, builder, pageNum);
 
-		recipe1 = loadRecipe(level, builder, entry, recipeId);
-		recipe2 = loadRecipe(level, builder, entry, recipe2Id);
+		recipe1 = loadRecipe(level, builder, entry, recipeId, linkRecipe);
+		recipe2 = loadRecipe(level, builder, entry, recipe2Id, linkRecipe2);
 
 		if (recipe1 == null && recipe2 != null) {
 			recipe1 = recipe2;
@@ -70,7 +72,7 @@ public abstract class PageDoubleRecipe<T> extends PageWithText {
 	}
 
 	protected abstract void drawRecipe(GuiGraphics graphics, T recipe, int recipeX, int recipeY, int mouseX, int mouseY, boolean second);
-	protected abstract T loadRecipe(Level level, BookContentsBuilder builder, BookEntry entry, ResourceLocation loc);
+	protected abstract T loadRecipe(Level level, BookContentsBuilder builder, BookEntry entry, ResourceLocation loc, boolean linkRecipe);
 	protected abstract ItemStack getRecipeOutput(Level level, T recipe);
 	protected abstract int getRecipeHeight();
 

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipeRegistry.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/page/abstr/PageDoubleRecipeRegistry.java
@@ -28,7 +28,7 @@ public abstract class PageDoubleRecipeRegistry<T extends Recipe<?>> extends Page
 	}
 
 	@Override
-	protected T loadRecipe(Level level, BookContentsBuilder builder, BookEntry entry, ResourceLocation res) {
+	protected T loadRecipe(Level level, BookContentsBuilder builder, BookEntry entry, ResourceLocation res, boolean linkRecipe) {
 		if (res == null || level == null) {
 			return null;
 		}
@@ -39,7 +39,9 @@ public abstract class PageDoubleRecipeRegistry<T extends Recipe<?>> extends Page
 		}
 
 		if (tempRecipe != null) {
-			entry.addRelevantStack(builder, tempRecipe.getResultItem(level.registryAccess()), pageNum);
+			if (linkRecipe) {
+				entry.addRelevantStack(builder, tempRecipe.getResultItem(level.registryAccess()), pageNum);
+			}
 			return tempRecipe;
 		}
 

--- a/Xplat/src/main/resources/assets/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/recipe_mapping/recipe.json
+++ b/Xplat/src/main/resources/assets/patchouli/patchouli_books/comprehensive_test_book/en_us/entries/recipe_mapping/recipe.json
@@ -9,6 +9,12 @@
       "recipe2": "minecraft:flint_and_steel"
     },
     {
+      "type": "patchouli:crafting",
+      "recipe": "minecraft:fletching_table",
+      "recipe2": "minecraft:snow",
+      "link_recipe": false
+    },
+    {
       "type": "patchouli:smelting",
       "recipe": "minecraft:cooked_cod"
     },


### PR DESCRIPTION
This PR introduces `link_recipe` and `link_recipe2` fileds to the double recipe page allowing the disabling of recipe linking for one or both recipes.
It adds a test page to the Comprehensive Test Book's recipe mapping Recipe entry that adds the recipe for both the Fletching Table and the Snow layer but only allowing the Snow layer to be linked.