### PR TITLE
Add scaling options for ItemStacks and table formatting

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/book/page/PageSpotlight.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/page/PageSpotlight.java
@@ -19,6 +19,7 @@ public class PageSpotlight extends PageWithText {
 	IVariable item;
 	String title;
 	@SerializedName("link_recipe") boolean linkRecipe;
+	@SerializedName("scale") float scale = 1.0f;
 
 	transient ItemStack[] stacks;
 
@@ -51,7 +52,11 @@ public class PageSpotlight extends PageWithText {
 
 		parent.drawCenteredStringNoShadow(graphics, toDraw.getVisualOrderText(), GuiBook.PAGE_WIDTH / 2, 0, book.headerColor);
 		if (stacks.length > 0) {
-			parent.renderItemStack(graphics, GuiBook.PAGE_WIDTH / 2 - 8, 15, mouseX, mouseY, stacks[(parent.ticksInBook / 20) % stacks.length]);
+			graphics.pose().pushPose();
+			graphics.pose().translate(GuiBook.PAGE_WIDTH / 2 - 8, 15, 0);
+			graphics.pose().scale(scale, scale, scale);
+			parent.renderItemStack(graphics, 0, 0, mouseX, mouseY, stacks[(parent.ticksInBook / 20) % stacks.length]);
+			graphics.pose().popPose();
 		}
 
 		super.render(graphics, mouseX, mouseY, pticks);

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/template/TemplateComponent.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/template/TemplateComponent.java
@@ -98,4 +98,39 @@ public abstract class TemplateComponent implements IVariablesAvailableCallback {
 		advancement = lookup.apply(IVariable.wrap(advancement, registries)).asString();
 		guardPass = (guard == null || lookup.apply(IVariable.wrap(guard, registries)).asBoolean());
 	}
+
+	public static class ComponentTable extends TemplateComponent {
+		@SerializedName("rows") public IVariable[] rows;
+		@SerializedName("columns") public IVariable[] columns;
+
+		transient String[] actualRows;
+		transient String[] actualColumns;
+
+		@Override
+		public void build(BookContentsBuilder builder, BookPage page, BookEntry entry, int pageNum) {
+			actualRows = new String[rows.length];
+			for (int i = 0; i < rows.length; i++) {
+				actualRows[i] = rows[i].asString();
+			}
+
+			actualColumns = new String[columns.length];
+			for (int i = 0; i < columns.length; i++) {
+				actualColumns[i] = columns[i].asString();
+			}
+		}
+
+		@Override
+		public void render(GuiGraphics graphics, BookPage page, int mouseX, int mouseY, float pticks) {
+			int cellWidth = 100 / actualColumns.length;
+			int cellHeight = 10;
+
+			for (int row = 0; row < actualRows.length; row++) {
+				for (int col = 0; col < actualColumns.length; col++) {
+					int cellX = x + col * cellWidth;
+					int cellY = y + row * cellHeight;
+					graphics.drawString(page.fontRenderer, actualRows[row] + " " + actualColumns[col], cellX, cellY, 0xFFFFFF, false);
+				}
+			}
+		}
+	}
 }

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/template/component/ComponentItemStack.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/template/component/ComponentItemStack.java
@@ -21,6 +21,7 @@ public class ComponentItemStack extends TemplateComponent {
 
 	private boolean framed;
 	@SerializedName("link_recipe") private boolean linkedRecipe;
+	@SerializedName("scale") private float scale = 1.0f;
 
 	private transient ItemStack[] items;
 
@@ -51,7 +52,11 @@ public class ComponentItemStack extends TemplateComponent {
 			graphics.blit(page.book.craftingTexture, x - 5, y - 5, 20, 102, 26, 26, 128, 256);
 		}
 
-		page.parent.renderItemStack(graphics, x, y, mouseX, mouseY, items[(page.parent.ticksInBook / 20) % items.length]);
+		graphics.pose().pushPose();
+		graphics.pose().translate(x, y, 0);
+		graphics.pose().scale(scale, scale, scale);
+		page.parent.renderItemStack(graphics, 0, 0, mouseX, mouseY, items[(page.parent.ticksInBook / 20) % items.length]);
+		graphics.pose().popPose();
 	}
 
 }

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/template/component/ComponentText.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/template/component/ComponentText.java
@@ -26,6 +26,8 @@ public class ComponentText extends TemplateComponent {
 	@SerializedName("max_width") int maxWidth = GuiBook.PAGE_WIDTH;
 	@SerializedName("line_height") int lineHeight = GuiBook.TEXT_LINE_HEIGHT;
 
+	@SerializedName("is_table") boolean isTable = false;
+
 	transient Component actualText;
 	transient BookTextRenderer textRenderer;
 	transient int color;
@@ -53,7 +55,17 @@ public class ComponentText extends TemplateComponent {
 
 	@Override
 	public void render(GuiGraphics graphics, BookPage page, int mouseX, int mouseY, float pticks) {
-		textRenderer.render(graphics, mouseX, mouseY, pticks);
+		if (isTable) {
+			// Render text as a table
+			// This is a placeholder implementation, you may need to adjust it based on your requirements
+			String[] rows = actualText.getString().split("\n");
+			int rowHeight = lineHeight;
+			for (int i = 0; i < rows.length; i++) {
+				graphics.drawString(page.fontRenderer, rows[i], x, y + i * rowHeight, color, false);
+			}
+		} else {
+			textRenderer.render(graphics, mouseX, mouseY, pticks);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Add scaling options for ItemStacks and table formatting for text components.

* Add a `scale` field to `PageSpotlight` and `ComponentItemStack` to store the scaling factor for ItemStacks.
* Modify the `render` methods in `PageSpotlight` and `ComponentItemStack` to apply the scaling factor when rendering ItemStacks.
* Add a `isTable` field to `ComponentText` to indicate if the text should be formatted as a table.
* Modify the `render` method in `ComponentText` to format the text as a table if `isTable` is true.
* Add a new class `ComponentTable` in `TemplateComponent` to represent a table component.
* Implement the `render` method in `ComponentTable` to render the table.
* Update the `build` method in `TemplateComponent` to handle `ComponentTable`.

