### PR TITLE
Extra-lazy parsing for custom book items

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -159,8 +159,16 @@ public class Book {
 		if (noBook) {
 			// Parse on load to catch errors, but need lazy loading for mods
 			// that load after Patchouli
-			var parsed = ItemStackUtil.deserializeStack(customBookItem, VanillaRegistries.createLookup());
-			bookItem = Suppliers.memoize(() -> ItemStackUtil.loadFromParsed(parsed));
+			bookItem = Suppliers.memoize(() -> {
+				try {
+					return ItemStackUtil.loadFromParsed(
+							ItemStackUtil.deserializeStack(customBookItem, VanillaRegistries.createLookup()));
+				} catch (Exception e) {
+					PatchouliAPI.LOGGER.error("Failed to parse item \"{}\" for book {} defined by mod {}, skipping",
+							customBookItem, id, owner.getId(), e);
+					return ItemStack.EMPTY;
+				}
+			});
 		} else {
 			bookItem = Suppliers.memoize(() -> ItemModBook.forBook(id));
 		}

--- a/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -164,7 +164,7 @@ public class Book {
 					return ItemStackUtil.loadFromParsed(
 							ItemStackUtil.deserializeStack(customBookItem, VanillaRegistries.createLookup()));
 				} catch (Exception e) {
-					PatchouliAPI.LOGGER.error("Failed to parse item \"{}\" for book {} defined by mod {}, skipping",
+					PatchouliAPI.LOGGER.warn("Failed to parse item \"{}\" for book {} defined by mod {}, skipping",
 							customBookItem, id, owner.getId(), e);
 					return ItemStack.EMPTY;
 				}

--- a/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
+++ b/Xplat/src/main/java/vazkii/patchouli/common/book/Book.java
@@ -157,8 +157,8 @@ public class Book {
 
 		var customBookItem = GsonHelper.getAsString(root, "custom_book_item", "");
 		if (noBook) {
-			// Parse on load to catch errors, but need lazy loading for mods
-			// that load after Patchouli
+			// Need lazy parsing for mods that load after Patchouli, as parser looks up item and components
+			// in registries; wrap in try-catch in case of faulty item definition
 			bookItem = Suppliers.memoize(() -> {
 				try {
 					return ItemStackUtil.loadFromParsed(


### PR DESCRIPTION
Since parsing uses registry-based vanilla logic now, it will not work before the book's mod has finished loading.

Fixes #790 at the expense of potentially delayed error reporting.