### PR TITLE
Fallback to Class.forName when the serviceloader isn't working

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
@@ -15,9 +15,9 @@ import vazkii.patchouli.common.base.PatchouliSounds;
 import vazkii.patchouli.common.book.Book;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.util.SerializationUtil;
+import vazkii.patchouli.xplat.IClientXplatAbstractions;
 
 import org.jetbrains.annotations.Nullable;
-import vazkii.patchouli.xplat.IClientXplatAbstractions;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
@@ -17,6 +17,7 @@ import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.util.SerializationUtil;
 
 import org.jetbrains.annotations.Nullable;
+import vazkii.patchouli.xplat.IClientXplatAbstractions;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -38,6 +39,9 @@ public class ClientBookRegistry {
 
 	public void init() {
 		addPageTypes();
+
+		// TODO: Just poking IClientXplatAbstractions to detect ServiceLoader problems now, rather than later
+		var unused = IClientXplatAbstractions.INSTANCE;
 	}
 
 	private void addPageTypes() {

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
@@ -1,11 +1,13 @@
 package vazkii.patchouli.xplat;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
+
 import vazkii.patchouli.api.PatchouliAPI;
 
 import java.util.ServiceLoader;

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
@@ -27,7 +27,7 @@ public interface IClientXplatAbstractions {
 			// No clue why. Just duct-tape it for now.
 			try {
 				IClientXplatAbstractions abs = (IClientXplatAbstractions) Class.forName("vazkii.patchouli.neoforge.client.NeoForgeClientXplatImpl").getConstructor().newInstance();
-				PatchouliAPI.LOGGER.error("Successfully loaded NeoForge backup, but the ServiceLoader wasn't working. Report this.", exception);
+				PatchouliAPI.LOGGER.fatal("Successfully loaded NeoForge backup, but the ServiceLoader wasn't working. Report this.", exception);
 				return abs;
 			} catch (Exception e) {
 				exception.addSuppressed(new RuntimeException("Failed to load NeoForge backup", e));
@@ -35,7 +35,7 @@ public interface IClientXplatAbstractions {
 
 			try {
 				IClientXplatAbstractions abs = (IClientXplatAbstractions) Class.forName("vazkii.patchouli.fabric.client.FabricClientXplatImpl").getConstructor().newInstance();
-				PatchouliAPI.LOGGER.error("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);
+				PatchouliAPI.LOGGER.fatal("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);
 				return abs;
 			} catch (Exception e) {
 				exception.addSuppressed(new RuntimeException("Failed to load Fabric backup", e));

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
@@ -1,13 +1,11 @@
 package vazkii.patchouli.xplat;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
-
 import vazkii.patchouli.api.PatchouliAPI;
 
 import java.util.ServiceLoader;
@@ -23,7 +21,27 @@ public interface IClientXplatAbstractions {
 		var providers = ServiceLoader.load(IClientXplatAbstractions.class).stream().toList();
 		if (providers.size() != 1) {
 			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
-			throw new IllegalStateException("There should be exactly one IClientXplatAbstractions implementation on the classpath. Found: " + names);
+			IllegalStateException exception = new IllegalStateException("There should be exactly one IClientXplatAbstractions implementation on the classpath, but there are " + providers.size() + ". Found: " + names);
+
+			//TODO: Something is breaking our serviceloader on NeoForge (see https://github.com/VazkiiMods/Patchouli/issues/792).
+			// No clue why. Just duct-tape it for now.
+			try {
+				IClientXplatAbstractions abs = (IClientXplatAbstractions) Class.forName("vazkii.patchouli.neoforge.client.NeoForgeClientXplatImpl").getConstructor().newInstance();
+				PatchouliAPI.LOGGER.error("Successfully loaded NeoForge backup, but the ServiceLoader wasn't working. Report this.", exception);
+				return abs;
+			} catch (Exception e) {
+				exception.addSuppressed(new RuntimeException("Failed to load NeoForge backup", e));
+			}
+
+			try {
+				IClientXplatAbstractions abs = (IClientXplatAbstractions) Class.forName("vazkii.patchouli.fabric.client.FabricClientXplatImpl").getConstructor().newInstance();
+				PatchouliAPI.LOGGER.error("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);
+				return abs;
+			} catch (Exception e) {
+				exception.addSuppressed(new RuntimeException("Failed to load Fabric backup", e));
+			}
+
+			throw exception;
 		} else {
 			var provider = providers.get(0);
 			PatchouliAPI.LOGGER.debug("Instantiating client xplat impl: " + provider.type().getName());

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
@@ -6,8 +6,10 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
-import org.jetbrains.annotations.Nullable;
+
 import vazkii.patchouli.api.PatchouliAPI;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.ServiceLoader;
@@ -57,7 +59,7 @@ public interface IXplatAbstractions {
 			} catch (Exception e) {
 				exception.addSuppressed(new RuntimeException("Failed to load NeoForge backup", e));
 			}
-	
+
 			try {
 				IXplatAbstractions abs = (IXplatAbstractions) Class.forName("vazkii.patchouli.fabric.xplat.FabricXplatImpl").getConstructor().newInstance();
 				PatchouliAPI.LOGGER.fatal("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
@@ -52,7 +52,7 @@ public interface IXplatAbstractions {
 			// No clue why. Just duct-tape it for now.
 			try {
 				IXplatAbstractions abs = (IXplatAbstractions) Class.forName("vazkii.patchouli.neoforge.xplat.NeoForgeXplatImpl").getConstructor().newInstance();
-				PatchouliAPI.LOGGER.error("Successfully loaded NeoForge backup, but the ServiceLoader wasn't working. Report this.", exception);
+				PatchouliAPI.LOGGER.fatal("Successfully loaded NeoForge backup, but the ServiceLoader wasn't working. Report this.", exception);
 				return abs;
 			} catch (Exception e) {
 				exception.addSuppressed(new RuntimeException("Failed to load NeoForge backup", e));
@@ -60,7 +60,7 @@ public interface IXplatAbstractions {
 	
 			try {
 				IXplatAbstractions abs = (IXplatAbstractions) Class.forName("vazkii.patchouli.fabric.xplat.FabricXplatImpl").getConstructor().newInstance();
-				PatchouliAPI.LOGGER.error("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);
+				PatchouliAPI.LOGGER.fatal("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);
 				return abs;
 			} catch (Exception e) {
 				exception.addSuppressed(new RuntimeException("Failed to load Fabric backup", e));

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
@@ -6,10 +6,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
-
-import vazkii.patchouli.api.PatchouliAPI;
-
 import org.jetbrains.annotations.Nullable;
+import vazkii.patchouli.api.PatchouliAPI;
 
 import java.util.Collection;
 import java.util.ServiceLoader;
@@ -48,7 +46,27 @@ public interface IXplatAbstractions {
 		var providers = ServiceLoader.load(IXplatAbstractions.class).stream().toList();
 		if (providers.size() != 1) {
 			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
-			throw new IllegalStateException("There should be exactly one IXplatAbstractions implementation on the classpath. Found: " + names);
+			IllegalStateException exception = new IllegalStateException("There should be exactly one IXplatAbstractions implementation on the classpath, but there are " + providers.size() + ". Found: " + names);
+
+			//TODO: Something is breaking our serviceloader on NeoForge (see https://github.com/VazkiiMods/Patchouli/issues/792).
+			// No clue why. Just duct-tape it for now.
+			try {
+				IXplatAbstractions abs = (IXplatAbstractions) Class.forName("vazkii.patchouli.neoforge.xplat.NeoForgeXplatImpl").getConstructor().newInstance();
+				PatchouliAPI.LOGGER.error("Successfully loaded NeoForge backup, but the ServiceLoader wasn't working. Report this.", exception);
+				return abs;
+			} catch (Exception e) {
+				exception.addSuppressed(new RuntimeException("Failed to load NeoForge backup", e));
+			}
+	
+			try {
+				IXplatAbstractions abs = (IXplatAbstractions) Class.forName("vazkii.patchouli.fabric.xplat.FabricXplatImpl").getConstructor().newInstance();
+				PatchouliAPI.LOGGER.error("Successfully loaded Fabric backup, but the ServiceLoader wasn't working. Report this.", exception);
+				return abs;
+			} catch (Exception e) {
+				exception.addSuppressed(new RuntimeException("Failed to load Fabric backup", e));
+			}
+
+			throw exception;
 		} else {
 			var provider = providers.get(0);
 			PatchouliAPI.LOGGER.debug("Instantiating xplat impl: " + provider.type().getName());


### PR DESCRIPTION
see #792, #795, #797, #800.

This is a really stupid fix, it's duct-tape, I just want the mod to stop crashing on people's computers. Nothing should ever break ServiceLoader.

Still logs an exception that the serviceloader failed. If Class.forName also somehow fails for both the fabric and forge classes, it will throw the exception.