### PR TITLE
Explicitly specify ClassLoader for ServiceLoader call

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
@@ -20,7 +20,7 @@ public interface IClientXplatAbstractions {
 	IClientXplatAbstractions INSTANCE = find();
 
 	private static IClientXplatAbstractions find() {
-		var providers = ServiceLoader.load(IClientXplatAbstractions.class).stream().toList();
+		var providers = ServiceLoader.load(IClientXplatAbstractions.class, IClientXplatAbstractions.class.getClassLoader()).stream().toList();
 		if (providers.size() != 1) {
 			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
 			throw new IllegalStateException("There should be exactly one IClientXplatAbstractions implementation on the classpath. Found: " + names);

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
@@ -45,7 +45,7 @@ public interface IXplatAbstractions {
 	IXplatAbstractions INSTANCE = find();
 
 	private static IXplatAbstractions find() {
-		var providers = ServiceLoader.load(IXplatAbstractions.class).stream().toList();
+		var providers = ServiceLoader.load(IXplatAbstractions.class, IXplatAbstractions.class.getClassLoader()).stream().toList();
 		if (providers.size() != 1) {
 			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
 			throw new IllegalStateException("There should be exactly one IXplatAbstractions implementation on the classpath. Found: " + names);


### PR DESCRIPTION
Hopefully fixes #792, #795, and #797, superseding the workaround in PR #801.