### PR TITLE
Allow vertical scrolling to turn the page

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/gui/GuiBook.java
@@ -346,9 +346,9 @@ public abstract class GuiBook extends Screen {
 
 	@Override
 	public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
-		if (scrollX < 0) {
+		if (scrollX < 0 || scrollY < 0) {
 			changePage(false, true);
-		} else if (scrollX > 0) {
+		} else if (scrollX > 0 || scrollY > 0) {
 			changePage(true, true);
 		}
 


### PR DESCRIPTION
Right now page turns rely on *horizontal* scrolling, which most mice don't have and is somewhat unintuitive. I thought you couldn't do it at all until I checked.

I made it so it's scroll down to go to the next page, scroll up to go to the previous page, while also keeping the horizontal scrolling the same.