### PR TITLE
Load books on first open

### DIFF
--- a/Xplat/src/main/java/vazkii/patchouli/client/base/ClientAdvancements.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/base/ClientAdvancements.java
@@ -22,17 +22,17 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 
 public class ClientAdvancements {
-	private static boolean gotFirstAdvPacket = false;
 
 	/* Hooked at the end of ClientAdvancementManager.read, when the advancement packet arrives clientside
 	The initial book load is done here when the first advancement packet arrives.
 	Doing it anytime before that leads to excessive toast spam because the book believes everything to be locked,
 	and then the first advancement packet unlocks everything.
+	Books may also be loaded lazily on first open via displayBookGui, for cases where
+	no advancement packet arrives before the book is opened.
 	*/
 	public static void onClientPacket() {
-		if (!gotFirstAdvPacket) {
+		if (!ClientBookRegistry.INSTANCE.hasReloadedContents()) {
 			ClientBookRegistry.INSTANCE.reload();
-			gotFirstAdvPacket = true;
 		} else {
 			ClientBookRegistry.INSTANCE.reloadLocks(false);
 		}
@@ -56,7 +56,7 @@ public class ClientAdvancements {
 	}
 
 	public static void playerLogout() {
-		gotFirstAdvPacket = false;
+		ClientBookRegistry.INSTANCE.resetReloadedState();
 	}
 
 	public static void sendBookToast(Book book) {

--- a/Xplat/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/book/ClientBookRegistry.java
@@ -31,6 +31,7 @@ public class ClientBookRegistry {
 			.registerTypeHierarchyAdapter(TemplateComponent.class, new TemplateComponentAdapter())
 			.create();
 	public String currentLang;
+	private boolean hasReloadedContents = false;
 
 	public static final ClientBookRegistry INSTANCE = new ClientBookRegistry();
 
@@ -62,10 +63,19 @@ public class ClientBookRegistry {
 	public void reload() {
 		currentLang = Minecraft.getInstance().getLanguageManager().getSelected();
 		BookRegistry.INSTANCE.reloadContents(Minecraft.getInstance().level);
+		hasReloadedContents = true;
 	}
 
 	public void reloadLocks(boolean suppressToasts) {
 		BookRegistry.INSTANCE.books.values().forEach(b -> b.reloadLocks(suppressToasts));
+	}
+
+	public boolean hasReloadedContents() {
+		return hasReloadedContents;
+	}
+
+	public void resetReloadedState() {
+		hasReloadedContents = false;
 	}
 
 	/**
@@ -73,6 +83,10 @@ public class ClientBookRegistry {
 	 * @param page    Zero-indexed page in the entry to force. Ignored if {@code entryId} is null.
 	 */
 	public void displayBookGui(ResourceLocation bookStr, @Nullable ResourceLocation entryId, int page) {
+		if (!hasReloadedContents) {
+			reload();
+		}
+
 		Minecraft mc = Minecraft.getInstance();
 		currentLang = mc.getLanguageManager().getSelected();
 


### PR DESCRIPTION
## What

Fixes #845

## Bug Details

Initial book loading is gated by ClientAdvancements::onClientPacket to prevent "excessive toast spam", as explained by the comment on that method.

However, when no advancements are registered or no advancements are achieved yet by the player, this never loads the books.

## Fix Details

If the books are unloaded at the moment of the player opening the book, then reload the books first.

We do still want to load the books when the first advancements package arrives, because we need to check if we need to toast, so both paths still exist and use a shared source of truth.