### PR TITLE
Harden API class loading startup logic (1.20.1)

### DIFF
--- a/Fabric/src/main/java/vazkii/patchouli/fabric/client/FabricClientInitializer.java
+++ b/Fabric/src/main/java/vazkii/patchouli/fabric/client/FabricClientInitializer.java
@@ -33,15 +33,21 @@ import vazkii.patchouli.common.item.ItemModBook;
 import vazkii.patchouli.common.item.PatchouliItems;
 import vazkii.patchouli.fabric.network.FabricMessageOpenBookGui;
 import vazkii.patchouli.fabric.network.FabricMessageReloadBookContents;
+import vazkii.patchouli.xplat.IClientXplatAbstractions;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 public class FabricClientInitializer implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
+		// ensure API implementations are loaded
+		PatchouliAPI.LOGGER.debug("Client API instances: {}",
+				List.of(IClientXplatAbstractions.INSTANCE));
+
 		ClientBookRegistry.INSTANCE.init();
 		PersistentData.setup();
 		ClientTickEvents.END_CLIENT_TICK.register(ClientTicker::endClientTick);

--- a/Fabric/src/main/java/vazkii/patchouli/fabric/common/FabricModInitializer.java
+++ b/Fabric/src/main/java/vazkii/patchouli/fabric/common/FabricModInitializer.java
@@ -12,6 +12,8 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
 
+import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.api.VariableHelper;
 import vazkii.patchouli.common.base.PatchouliSounds;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.command.OpenBookCommand;
@@ -19,10 +21,17 @@ import vazkii.patchouli.common.handler.LecternEventHandler;
 import vazkii.patchouli.common.handler.ReloadContentsHandler;
 import vazkii.patchouli.common.item.ItemModBook;
 import vazkii.patchouli.common.item.PatchouliItems;
+import vazkii.patchouli.xplat.IXplatAbstractions;
+
+import java.util.List;
 
 public class FabricModInitializer implements ModInitializer {
 	@Override
 	public void onInitialize() {
+		// ensure API implementations are loaded
+		PatchouliAPI.LOGGER.debug("API instances: {}",
+				List.of(PatchouliAPI.get(), IXplatAbstractions.INSTANCE, VariableHelper.instance()));
+
 		PatchouliSounds.submitRegistrations((id, e) -> Registry.register(BuiltInRegistries.SOUND_EVENT, id, e));
 		PatchouliItems.submitItemRegistrations((id, e) -> Registry.register(BuiltInRegistries.ITEM, id, e));
 		PatchouliItems.submitRecipeSerializerRegistrations((id, e) -> Registry.register(BuiltInRegistries.RECIPE_SERIALIZER, id, e));

--- a/Forge/src/main/java/vazkii/patchouli/forge/client/ForgeClientInitializer.java
+++ b/Forge/src/main/java/vazkii/patchouli/forge/client/ForgeClientInitializer.java
@@ -30,6 +30,7 @@ import vazkii.patchouli.client.handler.TooltipHandler;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.item.ItemModBook;
 import vazkii.patchouli.common.item.PatchouliItems;
+import vazkii.patchouli.xplat.IClientXplatAbstractions;
 
 import java.util.List;
 import java.util.concurrent.locks.Condition;
@@ -110,6 +111,10 @@ public class ForgeClientInitializer {
 
 	@SubscribeEvent
 	public static void onInitializeClient(FMLClientSetupEvent evt) {
+		// ensure API implementations are loaded
+		PatchouliAPI.LOGGER.debug("Client API instances: {}",
+				List.of(IClientXplatAbstractions.INSTANCE));
+
 		ClientBookRegistry.INSTANCE.init();
 		PersistentData.setup();
 		MinecraftForge.EVENT_BUS.addListener((TickEvent.ClientTickEvent e) -> {

--- a/Forge/src/main/java/vazkii/patchouli/forge/common/ForgeModInitializer.java
+++ b/Forge/src/main/java/vazkii/patchouli/forge/common/ForgeModInitializer.java
@@ -15,6 +15,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.registries.RegisterEvent;
 
 import vazkii.patchouli.api.PatchouliAPI;
+import vazkii.patchouli.api.VariableHelper;
 import vazkii.patchouli.common.base.PatchouliSounds;
 import vazkii.patchouli.common.book.BookRegistry;
 import vazkii.patchouli.common.command.OpenBookCommand;
@@ -23,11 +24,18 @@ import vazkii.patchouli.common.handler.ReloadContentsHandler;
 import vazkii.patchouli.common.item.ItemModBook;
 import vazkii.patchouli.common.item.PatchouliItems;
 import vazkii.patchouli.forge.network.ForgeNetworkHandler;
+import vazkii.patchouli.xplat.IXplatAbstractions;
+
+import java.util.List;
 
 @Mod.EventBusSubscriber(modid = PatchouliAPI.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
 @Mod(PatchouliAPI.MOD_ID)
 public class ForgeModInitializer {
 	public ForgeModInitializer() {
+		// ensure API implementations are loaded
+		PatchouliAPI.LOGGER.debug("API instances: {}",
+				List.of(PatchouliAPI.get(), IXplatAbstractions.INSTANCE, VariableHelper.instance()));
+
 		ForgePatchouliConfig.setup();
 	}
 

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IClientXplatAbstractions.java
@@ -8,26 +8,9 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
 
-import vazkii.patchouli.api.PatchouliAPI;
-
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
-
 public interface IClientXplatAbstractions {
 	// NB: Fluids handled at callsite in platform-independent manner
 	void renderForMultiblock(BlockState state, BlockPos pos, BlockAndTintGetter multiblock, PoseStack ps, MultiBufferSource buffers, RandomSource rand);
 
-	IClientXplatAbstractions INSTANCE = find();
-
-	private static IClientXplatAbstractions find() {
-		var providers = ServiceLoader.load(IClientXplatAbstractions.class).stream().toList();
-		if (providers.size() != 1) {
-			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
-			throw new IllegalStateException("There should be exactly one IClientXplatAbstractions implementation on the classpath. Found: " + names);
-		} else {
-			var provider = providers.get(0);
-			PatchouliAPI.LOGGER.debug("Instantiating client xplat impl: " + provider.type().getName());
-			return provider.get();
-		}
-	}
+	IClientXplatAbstractions INSTANCE = ServiceUtil.findService(IClientXplatAbstractions.class);
 }

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/IXplatAbstractions.java
@@ -7,13 +7,9 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
-import vazkii.patchouli.api.PatchouliAPI;
-
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 /**
  * Cross-modloader abstracted calls
@@ -42,17 +38,5 @@ public interface IXplatAbstractions {
 	// JEI/REI compat
 	boolean handleRecipeKeybind(int keyCode, int scanCode, ItemStack stack);
 
-	IXplatAbstractions INSTANCE = find();
-
-	private static IXplatAbstractions find() {
-		var providers = ServiceLoader.load(IXplatAbstractions.class).stream().toList();
-		if (providers.size() != 1) {
-			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
-			throw new IllegalStateException("There should be exactly one IXplatAbstractions implementation on the classpath. Found: " + names);
-		} else {
-			var provider = providers.get(0);
-			PatchouliAPI.LOGGER.debug("Instantiating xplat impl: " + provider.type().getName());
-			return provider.get();
-		}
-	}
+	IXplatAbstractions INSTANCE = ServiceUtil.findService(IXplatAbstractions.class);
 }

--- a/Xplat/src/main/java/vazkii/patchouli/xplat/ServiceUtil.java
+++ b/Xplat/src/main/java/vazkii/patchouli/xplat/ServiceUtil.java
@@ -1,0 +1,22 @@
+package vazkii.patchouli.xplat;
+
+import vazkii.patchouli.api.PatchouliAPI;
+
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+class ServiceUtil {
+	public static <T> T findService(Class<T> clazz) {
+		var providers = ServiceLoader.load(clazz, clazz.getClassLoader()).stream().toList();
+		if (providers.size() != 1) {
+			var names = providers.stream().map(p -> p.type().getName()).collect(Collectors.joining(",", "[", "]"));
+			var msg = "There should be exactly one implementation of %s on the classpath. Found: %s"
+					.formatted(clazz.getName(), names);
+			throw new IllegalStateException(msg);
+		} else {
+			var provider = providers.get(0);
+			PatchouliAPI.LOGGER.debug("Instantiating {} for service {}", provider.type().getName(), clazz.getName());
+			return provider.get();
+		}
+	}
+}


### PR DESCRIPTION
1.20.1 version of #818 to prevent crashes related to `ServiceLoader` logic failing, with additional upgrades from Botania.