### PR TITLE
Add ability to use ALT as quick-lookup key

### DIFF
--- a/Fabric/src/main/java/vazkii/patchouli/fabric/common/FiberPatchouliConfig.java
+++ b/Fabric/src/main/java/vazkii/patchouli/fabric/common/FiberPatchouliConfig.java
@@ -30,7 +30,8 @@ public class FiberPatchouliConfig {
 	public static PropertyMirror<List<String>> noAdvancementBooks = PropertyMirror.create(ConfigTypes.makeList(ConfigTypes.STRING));
 	public static PropertyMirror<Boolean> testingMode = PropertyMirror.create(ConfigTypes.BOOLEAN);
 	public static PropertyMirror<String> inventoryButtonBook = PropertyMirror.create(ConfigTypes.STRING);
-	public static PropertyMirror<Boolean> useShiftForQuickLookup = PropertyMirror.create(ConfigTypes.BOOLEAN);
+  private static final EnumConfigType<PatchouliConfigAccess.QuickLookupMode> QUICK_LOOKUP_TYPE = ConfigTypes.makeEnum(PatchouliConfigAccess.QuickLookupMode.class);
+	public static PropertyMirror<PatchouliConfigAccess.QuickLookupMode> quickLookupMode = PropertyMirror.create(QUICK_LOOKUP_TYPE);
 	private static final EnumConfigType<PatchouliConfigAccess.TextOverflowMode> OVERFLOW_TYPE = ConfigTypes.makeEnum(PatchouliConfigAccess.TextOverflowMode.class);
 	public static PropertyMirror<PatchouliConfigAccess.TextOverflowMode> overflowMode = PropertyMirror.create(OVERFLOW_TYPE);
 	public static PropertyMirror<Integer> quickLookupTime = PropertyMirror.create(ConfigTypes.INTEGER);
@@ -52,9 +53,9 @@ public class FiberPatchouliConfig {
 			.withComment("Set this to the ID of a book to have it show up in players' inventories, replacing the recipe book.")
 			.finishValue(inventoryButtonBook::mirror)
 
-			.beginValue("useShiftForQuickLookup", ConfigTypes.BOOLEAN, false)
-			.withComment("Set this to true to use Shift instead of Ctrl for the inventory quick lookup feature.")
-			.finishValue(useShiftForQuickLookup::mirror)
+			.beginValue("quickLookupMode", QUICK_LOOKUP_TYPE, PatchouliConfigAccess.QuickLookupMode.CTRL)
+			.withComment("Set the modifier key (CTRL, SHIFT, or ALT) to use for the inventory quick lookup feature.")
+			.finishValue(quickLookupMode::mirror)
 
 			.beginValue("textOverflowMode", OVERFLOW_TYPE, PatchouliConfigAccess.TextOverflowMode.RESIZE)
 			.withComment("Set how to handle text overflow: OVERFLOW the text off the page, TRUNCATE overflowed text, or RESIZE everything to fit. Relogin after changing.")
@@ -96,9 +97,7 @@ public class FiberPatchouliConfig {
 			}
 
 			@Override
-			public boolean useShiftForQuickLookup() {
-				return useShiftForQuickLookup.getValue();
-			}
+			public QuickLookupMode quickLookupMode() { return quickLookupMode.getValue(); }
 
 			@Override
 			public TextOverflowMode overflowMode() {

--- a/Forge/src/main/java/vazkii/patchouli/forge/common/ForgePatchouliConfig.java
+++ b/Forge/src/main/java/vazkii/patchouli/forge/common/ForgePatchouliConfig.java
@@ -5,6 +5,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
 
+import org.jetbrains.annotations.NotNull;
 import vazkii.patchouli.api.PatchouliConfigAccess;
 import vazkii.patchouli.common.base.PatchouliConfig;
 
@@ -16,7 +17,7 @@ public class ForgePatchouliConfig {
 	public static final ForgeConfigSpec.ConfigValue<List<? extends String>> noAdvancementBooks;
 	public static final ForgeConfigSpec.ConfigValue<Boolean> testingMode;
 	public static final ForgeConfigSpec.ConfigValue<String> inventoryButtonBook;
-	public static final ForgeConfigSpec.ConfigValue<Boolean> useShiftForQuickLookup;
+	public static final ForgeConfigSpec.ConfigValue<PatchouliConfigAccess.QuickLookupMode> quickLookupMode;
 	public static final ForgeConfigSpec.EnumValue<PatchouliConfigAccess.TextOverflowMode> overflowMode;
 	public static final ForgeConfigSpec.ConfigValue<Integer> quickLookupTime;
 
@@ -40,9 +41,9 @@ public class ForgePatchouliConfig {
 				.comment("Set this to the ID of a book to have it show up in players' inventories, replacing the recipe book.")
 				.define("inventoryButtonBook", "");
 
-		useShiftForQuickLookup = builder
-				.comment("Set this to true to use Shift instead of Ctrl for the inventory quick lookup feature.")
-				.define("useShiftForQuickLookup", false);
+		quickLookupMode = builder
+				.comment("Set the modifier key (CTRL, SHIFT, or ALT) to use for the inventory quick lookup feature.")
+				.defineEnum("quickLookupMode", PatchouliConfigAccess.QuickLookupMode.CTRL);
 
 		overflowMode = builder
 				.comment("Set how text overflow should be coped with: overflow the text off the page, truncate overflowed text, or resize everything to fit. Relogin after changing.")
@@ -82,9 +83,7 @@ public class ForgePatchouliConfig {
 			}
 
 			@Override
-			public boolean useShiftForQuickLookup() {
-				return useShiftForQuickLookup.get();
-			}
+			public QuickLookupMode quickLookupMode() { return quickLookupMode.get(); }
 
 			@Override
 			public TextOverflowMode overflowMode() {

--- a/Xplat/src/main/java/vazkii/patchouli/api/PatchouliConfigAccess.java
+++ b/Xplat/src/main/java/vazkii/patchouli/api/PatchouliConfigAccess.java
@@ -11,11 +11,21 @@ public interface PatchouliConfigAccess {
 
 	String inventoryButtonBook();
 
-	boolean useShiftForQuickLookup();
+	QuickLookupMode quickLookupMode();
+
+  default boolean useShiftForQuickLookup() {
+    return quickLookupMode() == QuickLookupMode.SHIFT;
+  }
 
 	TextOverflowMode overflowMode();
 
 	int quickLookupTime();
+
+  enum QuickLookupMode {
+    CTRL,
+    SHIFT,
+    ALT
+  }
 
 	enum TextOverflowMode {
 		OVERFLOW,

--- a/Xplat/src/main/java/vazkii/patchouli/api/stub/StubPatchouliAPI.java
+++ b/Xplat/src/main/java/vazkii/patchouli/api/stub/StubPatchouliAPI.java
@@ -66,9 +66,10 @@ public class StubPatchouliAPI implements IPatchouliAPI {
 				return "";
 			}
 
+      @NotNull
 			@Override
-			public boolean useShiftForQuickLookup() {
-				return false;
+			public QuickLookupMode quickLookupMode() {
+				return QuickLookupMode.CTRL;
 			}
 
 			@NotNull

--- a/Xplat/src/main/java/vazkii/patchouli/client/handler/TooltipHandler.java
+++ b/Xplat/src/main/java/vazkii/patchouli/client/handler/TooltipHandler.java
@@ -62,7 +62,12 @@ public class TooltipHandler {
 				graphics.fill(x - 4, tooltipY - 4, x + 20, tooltipY + 26, 0x44000000);
 				graphics.fill(x - 6, tooltipY - 6, x + 22, tooltipY + 28, 0x44000000);
 
-				if (PatchouliConfig.get().useShiftForQuickLookup() ? Screen.hasShiftDown() : Screen.hasControlDown()) {
+
+        if (switch (PatchouliConfig.get().quickLookupMode()) {
+          case CTRL -> Screen.hasControlDown();
+          case SHIFT -> Screen.hasShiftDown();
+          case ALT -> Screen.hasAltDown();
+        }) {
 					lexiconLookupTime += ClientTicker.delta;
 
 					int cx = x + 8;
@@ -111,8 +116,11 @@ public class TooltipHandler {
 
 				graphics.pose().scale(0.5F, 0.5F, 1F);
 				boolean mac = Minecraft.ON_OSX;
-				Component key = Component.literal(PatchouliConfig.get().useShiftForQuickLookup() ? "Shift" : mac ? "Cmd" : "Ctrl")
-						.withStyle(ChatFormatting.BOLD);
+				Component key = Component.literal(switch (PatchouliConfig.get().quickLookupMode()) {
+          case CTRL -> mac ? "Cmd" : "Ctrl";
+          case SHIFT -> "Shift";
+          case ALT -> "Alt";
+        }).withStyle(ChatFormatting.BOLD);
 				graphics.drawString(mc.font, key, (x + 10) * 2 - 16, (tooltipY + 8) * 2 + 20, 0xFFFFFFFF, true);
 				graphics.pose().popPose();
 


### PR DESCRIPTION
<img width="318" height="280" alt="image" src="https://github.com/user-attachments/assets/44f77f17-687c-40ac-9cc8-e06bfded92dc" />

I changed the config to use an enum instead of a "use Shift instead of Control" boolean.